### PR TITLE
Update attendee schema with default values

### DIFF
--- a/src/services/attendees/attendee-schema.ts
+++ b/src/services/attendees/attendee-schema.ts
@@ -12,19 +12,21 @@ const AttendeeValidator = z.object({
     hasCheckedIn: z.boolean().default(false),
     points: z.number().min(0).default(0),
     foodWave: z.number().int().min(0).default(0),
-    hasPriority: z.object({
-        dayOne: z.boolean().default(false),
-        dayTwo: z.boolean().default(false),
-        dayThree: z.boolean().default(false),
-        dayFour: z.boolean().default(false),
-        dayFive: z.boolean().default(false),
-    }).default({
-        dayOne: false,
-        dayTwo: false,
-        dayThree: false,
-        dayFour: false,
-        dayFive: false,
-    })
+    hasPriority: z
+        .object({
+            dayOne: z.boolean().default(false),
+            dayTwo: z.boolean().default(false),
+            dayThree: z.boolean().default(false),
+            dayFour: z.boolean().default(false),
+            dayFive: z.boolean().default(false),
+        })
+        .default({
+            dayOne: false,
+            dayTwo: false,
+            dayThree: false,
+            dayFour: false,
+            dayFive: false,
+        }),
 });
 
 // Mongoose schema for attendee

--- a/src/services/attendees/attendee-schema.ts
+++ b/src/services/attendees/attendee-schema.ts
@@ -6,19 +6,25 @@ const AttendeeValidator = z.object({
     userId: z.string(),
     name: z.string(),
     email: z.string().email(),
-    events: z.array(z.string()),
+    events: z.array(z.string()).default([]),
     dietaryRestrictions: z.string().array(),
     allergies: z.string().array(),
     hasCheckedIn: z.boolean().default(false),
     points: z.number().min(0).default(0),
     foodWave: z.number().int().min(0).default(0),
     hasPriority: z.object({
-        dayOne: z.boolean(),
-        dayTwo: z.boolean(),
-        dayThree: z.boolean(),
-        dayFour: z.boolean(),
-        dayFive: z.boolean(),
-    }),
+        dayOne: z.boolean().default(false),
+        dayTwo: z.boolean().default(false),
+        dayThree: z.boolean().default(false),
+        dayFour: z.boolean().default(false),
+        dayFive: z.boolean().default(false),
+    }).default({
+        dayOne: false,
+        dayTwo: false,
+        dayThree: false,
+        dayFour: false,
+        dayFive: false,
+    })
 });
 
 // Mongoose schema for attendee


### PR DESCRIPTION
`events` and `hasPriority` didn't have default values, so when /registration/submit tried to validate its data against the `AttendeeValidator`, it started complaining :')

changed it now to set the default `events` to an empty array and the default `hasPriority` to an _object_ with each day set to false (+ also defaulted each _day_ inside to false)