### PR TITLE
Add flexibility to s3

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,11 @@ export const Environment = z.enum(["PRODUCTION", "DEVELOPMENT", "TESTING"]);
 
 export const MailingListName = z.enum(["rp_interest"]);
 
+export enum BucketName {
+    RP_2024_RESUMES = "rp-2024-resumes",
+    RP_2024_SPEAKERS = "rp-2024-speakers",
+};
+
 export const Config = {
     DEFAULT_APP_PORT: 3000,
     ALLOWED_CORS_ORIGIN_PATTERNS: [
@@ -71,7 +76,6 @@ export const Config = {
 
     S3_ACCESS_KEY: getEnv("S3_ACCESS_KEY"),
     S3_SECRET_KEY: getEnv("S3_SECRET_KEY"),
-    S3_BUCKET_NAME: getEnv("S3_BUCKET_NAME"),
     S3_REGION: getEnv("S3_REGION"),
     MAX_RESUME_SIZE_BYTES: 6 * 1024 * 1024,
     RESUME_URL_EXPIRY_SECONDS: 60,

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ export const MailingListName = z.enum(["rp_interest"]);
 export enum BucketName {
     RP_2024_RESUMES = "rp-2024-resumes",
     RP_2024_SPEAKERS = "rp-2024-speakers",
-};
+}
 
 export const Config = {
     DEFAULT_APP_PORT: 3000,

--- a/src/services/s3/s3-router.ts
+++ b/src/services/s3/s3-router.ts
@@ -5,7 +5,7 @@ import { s3ClientMiddleware } from "../../middleware/s3";
 import { Role } from "../auth/auth-models";
 
 import { S3 } from "@aws-sdk/client-s3";
-import { getResumeUrl, postResumeUrl } from "./s3-utils";
+import { getUrl, postUrl } from "./s3-utils";
 import BatchResumeDownloadValidator from "./s3-schema";
 import { BucketName } from "../../config";
 
@@ -22,7 +22,7 @@ s3Router.get(
         const userId: string = payload.userId;
 
         try {
-            const { url, fields } = await postResumeUrl(
+            const { url, fields } = await postUrl(
                 userId,
                 s3,
                 BucketName.RP_2024_RESUMES
@@ -45,7 +45,7 @@ s3Router.get(
         const s3 = res.locals.s3 as S3;
 
         try {
-            const downloadUrl = await getResumeUrl(
+            const downloadUrl = await getUrl(
                 userId,
                 s3,
                 BucketName.RP_2024_RESUMES
@@ -66,7 +66,7 @@ s3Router.get(
         const s3 = res.locals.s3 as S3;
 
         try {
-            const downloadUrl = await getResumeUrl(
+            const downloadUrl = await getUrl(
                 userId,
                 s3,
                 BucketName.RP_2024_RESUMES
@@ -89,7 +89,7 @@ s3Router.get(
             const { userIds } = BatchResumeDownloadValidator.parse(req.body);
 
             const batchDownloadPromises = userIds.map((userId) =>
-                getResumeUrl(userId, s3, BucketName.RP_2024_RESUMES)
+                getUrl(userId, s3, BucketName.RP_2024_RESUMES)
                     .then((url) => ({ userId, url: url }))
                     .catch(() => ({ userId, url: null }))
             );

--- a/src/services/s3/s3-router.ts
+++ b/src/services/s3/s3-router.ts
@@ -7,6 +7,7 @@ import { Role } from "../auth/auth-models";
 import { S3 } from "@aws-sdk/client-s3";
 import { getResumeUrl, postResumeUrl } from "./s3-utils";
 import BatchResumeDownloadValidator from "./s3-schema";
+import { BucketName } from "../../config";
 
 const s3Router: Router = Router();
 
@@ -21,7 +22,11 @@ s3Router.get(
         const userId: string = payload.userId;
 
         try {
-            const { url, fields } = await postResumeUrl(userId, s3);
+            const { url, fields } = await postResumeUrl(
+                userId,
+                s3,
+                BucketName.RP_2024_RESUMES
+            );
             return res.status(StatusCodes.OK).send({ url, fields });
         } catch (error) {
             next(error);
@@ -40,7 +45,11 @@ s3Router.get(
         const s3 = res.locals.s3 as S3;
 
         try {
-            const downloadUrl = await getResumeUrl(userId, s3);
+            const downloadUrl = await getResumeUrl(
+                userId,
+                s3,
+                BucketName.RP_2024_RESUMES
+            );
             return res.status(StatusCodes.OK).send({ url: downloadUrl });
         } catch (error) {
             next(error);
@@ -57,7 +66,11 @@ s3Router.get(
         const s3 = res.locals.s3 as S3;
 
         try {
-            const downloadUrl = await getResumeUrl(userId, s3);
+            const downloadUrl = await getResumeUrl(
+                userId,
+                s3,
+                BucketName.RP_2024_RESUMES
+            );
             return res.status(StatusCodes.OK).send({ url: downloadUrl });
         } catch (error) {
             next(error);

--- a/src/services/s3/s3-router.ts
+++ b/src/services/s3/s3-router.ts
@@ -89,7 +89,7 @@ s3Router.get(
             const { userIds } = BatchResumeDownloadValidator.parse(req.body);
 
             const batchDownloadPromises = userIds.map((userId) =>
-                getResumeUrl(userId, s3)
+                getResumeUrl(userId, s3, BucketName.RP_2024_RESUMES)
                     .then((url) => ({ userId, url: url }))
                     .catch(() => ({ userId, url: null }))
             );

--- a/src/services/s3/s3-utils.ts
+++ b/src/services/s3/s3-utils.ts
@@ -3,7 +3,7 @@ import { Config, BucketName } from "../../config";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 
-export async function postResumeUrl(
+export async function postUrl(
     userId: string,
     client: S3,
     bucketName: BucketName
@@ -24,7 +24,7 @@ export async function postResumeUrl(
     return { url, fields };
 }
 
-export async function getResumeUrl(
+export async function getUrl(
     userId: string,
     client: S3,
     bucketName: BucketName

--- a/src/services/s3/s3-utils.ts
+++ b/src/services/s3/s3-utils.ts
@@ -1,11 +1,15 @@
 import { GetObjectCommand, S3 } from "@aws-sdk/client-s3";
-import Config from "../../config";
+import { Config, BucketName } from "../../config";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 
-export async function postResumeUrl(userId: string, client: S3) {
+export async function postResumeUrl(
+    userId: string,
+    client: S3,
+    bucketName: BucketName
+) {
     const { url, fields } = await createPresignedPost(client, {
-        Bucket: Config.S3_BUCKET_NAME,
+        Bucket: bucketName as string,
         Key: `${userId}.pdf`,
         Conditions: [
             ["content-length-range", 0, Config.MAX_RESUME_SIZE_BYTES], // 6 MB max
@@ -20,9 +24,13 @@ export async function postResumeUrl(userId: string, client: S3) {
     return { url, fields };
 }
 
-export async function getResumeUrl(userId: string, client: S3) {
+export async function getResumeUrl(
+    userId: string,
+    client: S3,
+    bucketName: BucketName
+) {
     const command = new GetObjectCommand({
-        Bucket: Config.S3_BUCKET_NAME,
+        Bucket: bucketName as string,
         Key: `${userId}.pdf`,
     });
 


### PR DESCRIPTION
Change/PR 1: add flexibility to s3
make changes to config.ts with a new native enum (non-zod) for bucket names.
enum names should be all caps, bucket names should not
in the enum, add current resume bucket rp-2024-resumes, but also add one for speakers (rp-2024-speakers)
pass that enum as a parameter into the get/postUrl methods in s3-utils.ts
use that enum's value to get the actual bucket name, instead of the config/env value (you can delete the current hardcoded bucket from config)