### PR TITLE
no eventId in put or post

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -5,7 +5,7 @@ import {
 } from "./services/attendee/attendee-schema";
 import {
     EventSchema,
-    privateEventValidator,
+    internalEventView,
 } from "./services/events/events-schema";
 import {
     EventAttendanceSchema,
@@ -70,7 +70,7 @@ function initializeModel(
 // Example usage
 export const Database = {
     ROLES: initializeModel("roles", RoleSchema, RoleValidator),
-    EVENTS: initializeModel("events", EventSchema, privateEventValidator),
+    EVENTS: initializeModel("events", EventSchema, internalEventView),
     EVENTS_ATTENDANCE: initializeModel(
         "events_attendance",
         EventAttendanceSchema,

--- a/src/services/events/events-router.ts
+++ b/src/services/events/events-router.ts
@@ -102,6 +102,11 @@ eventsRouter.post(
     RoleChecker([Role.Enum.STAFF]),
     async (req, res, next) => {
         try {
+            if (req.body.eventId) {
+                return res.status(StatusCodes.BAD_REQUEST).json({
+                    error: "Invalid Parameters",
+                });
+            }
             const validatedData = privateEventValidator.parse(req.body);
             const event = new Database.EVENTS(validatedData);
             await event.save();
@@ -118,7 +123,13 @@ eventsRouter.put(
     async (req, res, next) => {
         const eventId = req.params.EVENTID;
         try {
+            if (req.body.eventId) {
+                return res.status(StatusCodes.BAD_REQUEST).json({
+                    error: "Invalid Parameters",
+                });
+            }
             const validatedData = privateEventValidator.parse(req.body);
+            validatedData.eventId = eventId;
             const event = await Database.EVENTS.findOneAndUpdate(
                 { eventId: eventId },
                 { $set: validatedData }

--- a/src/services/events/events-router.ts
+++ b/src/services/events/events-router.ts
@@ -2,7 +2,11 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import { Router } from "express";
 import { StatusCodes } from "http-status-codes";
-import { publicEventValidator, privateEventValidator } from "./events-schema";
+import {
+    externalEventView,
+    internalEventView,
+    eventInfoValidator,
+} from "./events-schema";
 import { Database } from "../../database";
 import RoleChecker from "../../middleware/role-checker";
 import { Role } from "../auth/auth-models";
@@ -49,10 +53,10 @@ eventsRouter.get("/", RoleChecker([], true), async (req, res, next) => {
         var unfiltered_events = await Database.EVENTS.find();
 
         if (isStaff(payload) || isAdmin(payload)) {
-            filterFunction = (x: any) => privateEventValidator.parse(x);
+            filterFunction = (x: any) => internalEventView.parse(x);
         } else {
             unfiltered_events = unfiltered_events.filter((x) => x.isVisible);
-            filterFunction = (x: any) => publicEventValidator.parse(x);
+            filterFunction = (x: any) => externalEventView.parse(x);
         }
 
         const filtered_events = unfiltered_events.map(filterFunction);
@@ -80,9 +84,9 @@ eventsRouter.get("/:EVENTID", RoleChecker([], true), async (req, res, next) => {
         }
 
         if (isStaff(payload) || isAdmin(payload)) {
-            filterFunction = privateEventValidator.parse;
+            filterFunction = internalEventView.parse;
         } else {
-            filterFunction = publicEventValidator.parse;
+            filterFunction = externalEventView.parse;
             if (!event.isVisible) {
                 return res
                     .status(StatusCodes.NOT_FOUND)
@@ -102,12 +106,8 @@ eventsRouter.post(
     RoleChecker([Role.Enum.STAFF]),
     async (req, res, next) => {
         try {
-            if (req.body.eventId) {
-                return res.status(StatusCodes.BAD_REQUEST).json({
-                    error: "Invalid Parameters",
-                });
-            }
-            const validatedData = privateEventValidator.parse(req.body);
+            const validatedData = eventInfoValidator.parse(req.body);
+            console.log("ok");
             const event = new Database.EVENTS(validatedData);
             await event.save();
             return res.sendStatus(StatusCodes.CREATED);
@@ -123,12 +123,8 @@ eventsRouter.put(
     async (req, res, next) => {
         const eventId = req.params.EVENTID;
         try {
-            if (req.body.eventId) {
-                return res.status(StatusCodes.BAD_REQUEST).json({
-                    error: "Invalid Parameters",
-                });
-            }
-            const validatedData = privateEventValidator.parse(req.body);
+            eventInfoValidator.parse(req.body);
+            const validatedData = internalEventView.parse(req.body);
             validatedData.eventId = eventId;
             const event = await Database.EVENTS.findOneAndUpdate(
                 { eventId: eventId },

--- a/src/services/events/events-router.ts
+++ b/src/services/events/events-router.ts
@@ -107,7 +107,6 @@ eventsRouter.post(
     async (req, res, next) => {
         try {
             const validatedData = eventInfoValidator.parse(req.body);
-            console.log("ok");
             const event = new Database.EVENTS(validatedData);
             await event.save();
             return res.sendStatus(StatusCodes.CREATED);

--- a/src/services/events/events-schema.ts
+++ b/src/services/events/events-schema.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 
 export const EventType = z.enum(["A", "B", "C"]);
 
-export const publicEventValidator = z.object({
+export const externalEventView = z.object({
     eventId: z.coerce.string().default(() => uuidv4()),
     name: z.string(),
     startTime: z.coerce.date(),
@@ -17,10 +17,14 @@ export const publicEventValidator = z.object({
     eventType: EventType,
 });
 
-export const privateEventValidator = publicEventValidator.extend({
+export const internalEventView = externalEventView.extend({
     attendanceCount: z.number(),
     isVisible: z.boolean(),
 });
+
+export const eventInfoValidator = internalEventView
+    .omit({ eventId: true })
+    .strict();
 
 export const EventSchema = new Schema({
     eventId: {


### PR DESCRIPTION
POST /events
- Doesn't accept eventId
- Instead, a uuid is generated whenever a new event is created
PUT /events
- Doesn't accept eventId
- Maintains old eventId while updating other fields