### PR TITLE
Turn off weak verify for most endpoints

### DIFF
--- a/src/services/auth/auth-router.ts
+++ b/src/services/auth/auth-router.ts
@@ -154,7 +154,7 @@ authRouter.get("/dev/", (req, res) => {
 
 authRouter.get(
     "/corporate",
-    RoleChecker([Role.Enum.ADMIN], true),
+    RoleChecker([Role.Enum.ADMIN]),
     async (req, res, next) => {
         try {
             const allCorporate = await Database.CORPORATE.find();
@@ -168,7 +168,7 @@ authRouter.get(
 
 authRouter.post(
     "/corporate",
-    RoleChecker([Role.Enum.ADMIN], true),
+    RoleChecker([Role.Enum.ADMIN]),
     async (req, res, next) => {
         try {
             const attendeeData = CorporateValidator.parse(req.body);
@@ -184,7 +184,7 @@ authRouter.post(
 
 authRouter.delete(
     "/corporate",
-    RoleChecker([Role.Enum.ADMIN], true),
+    RoleChecker([Role.Enum.ADMIN]),
     async (req, res, next) => {
         try {
             const attendeeData = CorporateDeleteRequest.parse(req.body);

--- a/src/services/events/events-router.ts
+++ b/src/services/events/events-router.ts
@@ -117,7 +117,7 @@ eventsRouter.post(
 
 eventsRouter.put(
     "/:EVENTID",
-    RoleChecker([Role.Enum.STAFF], true),
+    RoleChecker([Role.Enum.STAFF]),
     async (req, res, next) => {
         const eventId = req.params.EVENTID;
         try {
@@ -145,7 +145,7 @@ eventsRouter.put(
 // Delete event
 eventsRouter.delete(
     "/:EVENTID",
-    RoleChecker([Role.Enum.STAFF], true),
+    RoleChecker([Role.Enum.STAFF]),
     async (req, res, next) => {
         const eventId = req.params.EVENTID;
         try {

--- a/src/services/speakers/speakers-router.ts
+++ b/src/services/speakers/speakers-router.ts
@@ -59,7 +59,7 @@ speakersRouter.post(
 // Update a speaker
 speakersRouter.put(
     "/:SPEAKERID",
-    RoleChecker([Role.Enum.STAFF], true),
+    RoleChecker([Role.Enum.STAFF]),
     async (req, res, next) => {
         const speakerId = req.params.SPEAKERID;
 
@@ -87,7 +87,7 @@ speakersRouter.put(
 // Delete a speaker
 speakersRouter.delete(
     "/:SPEAKERID",
-    RoleChecker([Role.Enum.STAFF], true),
+    RoleChecker([Role.Enum.STAFF]),
     async (req, res, next) => {
         const speakerId = req.params.SPEAKERID;
 

--- a/src/services/stats/stats-router.ts
+++ b/src/services/stats/stats-router.ts
@@ -98,7 +98,7 @@ statsRouter.get(
 // Get the dietary restriction breakdown/counts (staff only)
 statsRouter.get(
     "/dietary-restrictions",
-    RoleChecker([Role.enum.STAFF], true),
+    RoleChecker([Role.enum.STAFF], false),
     async (req, res, next) => {
         try {
             const results = await Promise.allSettled([


### PR DESCRIPTION
Turn off weak verify for most endpoints, needs a second review to confirm which endpoints should require jwt or not