### PR TITLE
Added speakers router testing

### DIFF
--- a/src/services/speakers/speakers-router.test.ts
+++ b/src/services/speakers/speakers-router.test.ts
@@ -72,11 +72,11 @@ describe("GET /speakers/", () => {
     it("should return all speakers when speakers exist", async () => {
         const response = await get("/speakers/").expect(StatusCodes.OK);
         expect(response.body).toEqual(
-                        expect.arrayContaining([
-                            expect.objectContaining(SPEAKER_1),
-                            expect.objectContaining(SPEAKER_2),
-                        ])
-                    );
+            expect.arrayContaining([
+                expect.objectContaining(SPEAKER_1),
+                expect.objectContaining(SPEAKER_2),
+            ])
+        );
     });
 
     it("should return an empty array when no speakers exist", async () => {
@@ -88,17 +88,17 @@ describe("GET /speakers/", () => {
 
 describe("GET /speakers/:SPEAKERID", () => {
     it("should return a specific speaker when a valid speakerId is provided", async () => {
-        const response = await get(
-                        `/speakers/${SPEAKER_1.speakerId}`
-                    ).expect(StatusCodes.OK);
-                    expect(response.body).toMatchObject(SPEAKER_1);
+        const response = await get(`/speakers/${SPEAKER_1.speakerId}`).expect(
+            StatusCodes.OK
+        );
+        expect(response.body).toMatchObject(SPEAKER_1);
     });
 
     it("should return NOT_FOUND when speakerId does not exist", async () => {
         const response = await get(
-                    `/speakers/${NON_EXISTENT_SPEAKER_ID}`
-                ).expect(StatusCodes.NOT_FOUND);
-                expect(response.body).toEqual({ error: "DoesNotExist" });
+            `/speakers/${NON_EXISTENT_SPEAKER_ID}`
+        ).expect(StatusCodes.NOT_FOUND);
+        expect(response.body).toEqual({ error: "DoesNotExist" });
     });
 });
 
@@ -110,42 +110,64 @@ describe("POST /speakers/", () => {
     });
 
     it("should create and return a new speaker with auto-generated speakerId when speakerId is not provided in payload", async () => {
-        const response = await postAsAdmin("/speakers/").send(NEW_SPEAKER_PAYLOAD_NO_ID).expect(StatusCodes.CREATED);
+        const response = await postAsAdmin("/speakers/")
+            .send(NEW_SPEAKER_PAYLOAD_NO_ID)
+            .expect(StatusCodes.CREATED);
 
-        expect(response.body).toMatchObject({...NEW_SPEAKER_PAYLOAD_NO_ID, speakerId: response.body.speakerId});
+        expect(response.body).toMatchObject({
+            ...NEW_SPEAKER_PAYLOAD_NO_ID,
+            speakerId: response.body.speakerId,
+        });
 
-        expect(response.body.speakerId).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
+        expect(response.body.speakerId).toMatch(
+            /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+        );
 
         const createdSpeaker = await Database.SPEAKERS.findOne({
-                    speakerId: response.body.speakerId,
-                });
-        expect(createdSpeaker?.toObject()).toMatchObject({...NEW_SPEAKER_PAYLOAD_NO_ID, speakerId: response.body.speakerId});
+            speakerId: response.body.speakerId,
+        });
+        expect(createdSpeaker?.toObject()).toMatchObject({
+            ...NEW_SPEAKER_PAYLOAD_NO_ID,
+            speakerId: response.body.speakerId,
+        });
     });
 
     it("should create and return a new speaker with provided speakerId when valid speakerId is in payload", async () => {
-        const response = await postAsAdmin("/speakers/").send(NEW_SPEAKER_PAYLOAD_WITH_ID).expect(StatusCodes.CREATED);
+        const response = await postAsAdmin("/speakers/")
+            .send(NEW_SPEAKER_PAYLOAD_WITH_ID)
+            .expect(StatusCodes.CREATED);
 
         expect(response.body).toMatchObject(NEW_SPEAKER_PAYLOAD_WITH_ID);
 
         const createdSpeaker = await Database.SPEAKERS.findOne({
-                    speakerId: NEW_SPEAKER_PAYLOAD_WITH_ID.speakerId,
-                });
-        expect(createdSpeaker?.toObject()).toMatchObject(NEW_SPEAKER_PAYLOAD_WITH_ID);
+            speakerId: NEW_SPEAKER_PAYLOAD_WITH_ID.speakerId,
+        });
+        expect(createdSpeaker?.toObject()).toMatchObject(
+            NEW_SPEAKER_PAYLOAD_WITH_ID
+        );
     });
 
     it("should return BAD_REQUEST if trying to create a speaker with an already existing speakerId", async () => {
         const payloadWithExistingId = {
             ...NEW_SPEAKER_PAYLOAD_NO_ID,
             speakerId: SPEAKER_1_ID,
-        }
+        };
 
-        const response = await postAsStaff("/speakers/").send(payloadWithExistingId).expect(StatusCodes.BAD_REQUEST);
+        const response = await postAsStaff("/speakers/")
+            .send(payloadWithExistingId)
+            .expect(StatusCodes.BAD_REQUEST);
         expect(response.body).toEqual({ error: "UserAlreadyExists" });
-    })
+    });
 
     const invalidPayloads = [
-        { description: "missing 'name' field", payload: { ...NEW_SPEAKER_PAYLOAD_NO_ID, name: undefined } },
-        { description: "'name' field is not a string", payload: { ...NEW_SPEAKER_PAYLOAD_NO_ID, name: 12345 } },
+        {
+            description: "missing 'name' field",
+            payload: { ...NEW_SPEAKER_PAYLOAD_NO_ID, name: undefined },
+        },
+        {
+            description: "'name' field is not a string",
+            payload: { ...NEW_SPEAKER_PAYLOAD_NO_ID, name: 12345 },
+        },
         { description: "payload is an empty object", payload: {} },
     ];
 
@@ -162,8 +184,8 @@ describe("POST /speakers/", () => {
 describe("PUT /speakers/:SPEAKERID", () => {
     it("should return UNAUTHORIZED for an unauthenticated user", async () => {
         await put(`/speakers/${SPEAKER_1.speakerId}`).expect(
-                    StatusCodes.UNAUTHORIZED
-                );
+            StatusCodes.UNAUTHORIZED
+        );
     });
 
     it("should update speaker and return 200 OK with updated speaker", async () => {
@@ -171,23 +193,41 @@ describe("PUT /speakers/:SPEAKERID", () => {
             .send(UPDATE_SPEAKER_PAYLOAD)
             .expect(StatusCodes.OK);
 
-        expect(response.body).toMatchObject( {...UPDATE_SPEAKER_PAYLOAD, speakerId: SPEAKER_1_ID} );
+        expect(response.body).toMatchObject({
+            ...UPDATE_SPEAKER_PAYLOAD,
+            speakerId: SPEAKER_1_ID,
+        });
 
         // ensure speakerId was not overwritten
         expect(response.body.speakerId).toBe(SPEAKER_1_ID);
 
-        const speakerAfterUpdate = await Database.SPEAKERS.findOne({ speakerId: response.body.speakerId });
-        expect(speakerAfterUpdate).toMatchObject( {...UPDATE_SPEAKER_PAYLOAD, speakerId: SPEAKER_1.speakerId} );
+        const speakerAfterUpdate = await Database.SPEAKERS.findOne({
+            speakerId: response.body.speakerId,
+        });
+        expect(speakerAfterUpdate).toMatchObject({
+            ...UPDATE_SPEAKER_PAYLOAD,
+            speakerId: SPEAKER_1.speakerId,
+        });
     });
 
-    it("should return 404 NOT_FOUND when trying to update a speaker that does not exist", async()=> {
-        const response = await putAsStaff(`/speakers/${NON_EXISTENT_SPEAKER_ID}`).send(UPDATE_SPEAKER_PAYLOAD).expect(StatusCodes.NOT_FOUND);
+    it("should return 404 NOT_FOUND when trying to update a speaker that does not exist", async () => {
+        const response = await putAsStaff(
+            `/speakers/${NON_EXISTENT_SPEAKER_ID}`
+        )
+            .send(UPDATE_SPEAKER_PAYLOAD)
+            .expect(StatusCodes.NOT_FOUND);
         expect(response.body).toEqual({ error: "DoesNotExist" });
-    })
+    });
 
     const invalidUpdatePayloads = [
-        { description: "missing 'name' field", payload: { ...UPDATE_SPEAKER_PAYLOAD, name: undefined } },
-        { description: "'title' field is not a string", payload: { ...UPDATE_SPEAKER_PAYLOAD, title: 12345 } },
+        {
+            description: "missing 'name' field",
+            payload: { ...UPDATE_SPEAKER_PAYLOAD, name: undefined },
+        },
+        {
+            description: "'title' field is not a string",
+            payload: { ...UPDATE_SPEAKER_PAYLOAD, title: 12345 },
+        },
         { description: "payload is an empty object", payload: {} },
     ];
 
@@ -199,7 +239,6 @@ describe("PUT /speakers/:SPEAKERID", () => {
                 .expect(StatusCodes.BAD_REQUEST);
         }
     );
-    
 });
 
 describe("DELETE /speakers/:SPEAKERID", () => {
@@ -210,16 +249,20 @@ describe("DELETE /speakers/:SPEAKERID", () => {
     });
 
     it("should delete an existing speaker and return 204 NO_CONTENT", async () => {
-        await delAsAdmin(`/speakers/${SPEAKER_1.speakerId}`).expect(StatusCodes.NO_CONTENT);
-        
-        const deletedSpeaker = await Database.SPEAKERS.findOne({ speakerId: SPEAKER_1.speakerId });
+        await delAsAdmin(`/speakers/${SPEAKER_1.speakerId}`).expect(
+            StatusCodes.NO_CONTENT
+        );
+
+        const deletedSpeaker = await Database.SPEAKERS.findOne({
+            speakerId: SPEAKER_1.speakerId,
+        });
         expect(deletedSpeaker).toBeNull();
     });
 
     it("should return NOT_FOUND when trying to delete a speaker that doesn't exist", async () => {
         const response = await delAsStaff(
-                    `/speakers/${NON_EXISTENT_SPEAKER_ID}`
-                ).expect(StatusCodes.NOT_FOUND);
-                expect(response.body).toEqual({ error: "DoesNotExist" });
+            `/speakers/${NON_EXISTENT_SPEAKER_ID}`
+        ).expect(StatusCodes.NOT_FOUND);
+        expect(response.body).toEqual({ error: "DoesNotExist" });
     });
 });

--- a/src/services/speakers/speakers-router.test.ts
+++ b/src/services/speakers/speakers-router.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import {
+    get,
+    post,
+    postAsStaff,
+    postAsAdmin,
+    put,
+    putAsStaff,
+    putAsAdmin,
+    del,
+    delAsStaff,
+    delAsAdmin,
+} from "../../../testing/testingTools";
+import { StatusCodes } from "http-status-codes";
+import { Database } from "../../database";
+import { v4 as uuidv4 } from "uuid";
+import { SpeakerType } from "./speakers-schema";
+
+const SPEAKER_1_ID = uuidv4();
+const SPEAKER_2_ID = uuidv4();
+const NON_EXISTENT_SPEAKER_ID = uuidv4();
+
+const SPEAKER_1 = {
+    speakerId: SPEAKER_1_ID,
+    name: "LeBron James",
+    title: "Professional Basketball Player",
+    bio: "The GOAT.",
+    eventTitle: "How to Play Basketball Like Me",
+    eventDescription: "A deep dive into the talent of LeBron James.",
+    imgUrl: "https://example.com/lebron_james.jpg",
+} satisfies SpeakerType;
+
+const SPEAKER_2 = {
+    speakerId: SPEAKER_2_ID,
+    name: "Sam Altman",
+    title: "ChatGPT Dude",
+    bio: "Listen to the guy who ceo of chatgpt explain how chatgpt works.",
+    eventTitle: "DIY ChatGPT",
+    eventDescription: "Exploring the inner workings of ChatGPT.",
+    imgUrl: "https://example.com/sam_altman.jpg",
+} satisfies SpeakerType;
+
+const NEW_SPEAKER_PAYLOAD_NO_ID = {
+    name: "Tom and Jerry",
+    title: "Cat and Mouse",
+    bio: "Watch cat chase mouse.",
+    eventTitle: "Tom and Jerry Grand Chase",
+    eventDescription: "Watching a cat chase a mouse throughout the house.",
+    imgUrl: "https://example.com/tom_and_jerry.jpg",
+} satisfies Omit<SpeakerType, "speakerId">;
+
+const NEW_SPEAKER_PAYLOAD_WITH_ID = {
+    ...NEW_SPEAKER_PAYLOAD_NO_ID,
+    speakerId: uuidv4(),
+} satisfies SpeakerType;
+
+const UPDATE_SPEAKER_PAYLOAD = {
+    name: "LeBron Raymone James",
+    title: "GOAT.",
+    bio: SPEAKER_1.bio + " of everything",
+    eventTitle: "How to Get Goated Like LeBron",
+    eventDescription: SPEAKER_1.eventDescription + " and meet and greet",
+    imgUrl: "https://example.com/lebron_james_updated.jpg",
+} satisfies Omit<SpeakerType, "speakerId">;
+
+beforeEach(async () => {
+    await Database.SPEAKERS.create(SPEAKER_1);
+    await Database.SPEAKERS.create(SPEAKER_2);
+});
+
+describe("GET /speakers/", () => {
+    it("should return all speakers when speakers exist", async () => {
+        const response = await get("/speakers/").expect(StatusCodes.OK);
+        expect(response.body).toEqual(
+                        expect.arrayContaining([
+                            expect.objectContaining(SPEAKER_1),
+                            expect.objectContaining(SPEAKER_2),
+                        ])
+                    );
+    });
+
+    it("should return an empty array when no speakers exist", async () => {
+        await Database.SPEAKERS.deleteMany({});
+        const response = await get("/speakers/").expect(StatusCodes.OK);
+        expect(response.body).toEqual([]);
+    });
+});
+
+describe("GET /speakers/:SPEAKERID", () => {
+    it("should return a specific speaker when a valid speakerId is provided", async () => {
+        const response = await get(
+                        `/speakers/${SPEAKER_1.speakerId}`
+                    ).expect(StatusCodes.OK);
+                    expect(response.body).toMatchObject(SPEAKER_1);
+    });
+
+    it("should return NOT_FOUND when speakerId does not exist", async () => {
+        const response = await get(
+                    `/speakers/${NON_EXISTENT_SPEAKER_ID}`
+                ).expect(StatusCodes.NOT_FOUND);
+                expect(response.body).toEqual({ error: "DoesNotExist" });
+    });
+});
+
+describe("POST /speakers/", () => {
+    it("should return UNAUTHORIZED for an unauthenticated user", async () => {
+        await post("/speakers/")
+            .send(NEW_SPEAKER_PAYLOAD_NO_ID)
+            .expect(StatusCodes.UNAUTHORIZED);
+    });
+
+    it("should create and return a new speaker with auto-generated speakerId when speakerId is not provided in payload", async () => {
+        const response = await postAsAdmin("/speakers/").send(NEW_SPEAKER_PAYLOAD_NO_ID).expect(StatusCodes.CREATED);
+
+        expect(response.body).toMatchObject({...NEW_SPEAKER_PAYLOAD_NO_ID, speakerId: response.body.speakerId});
+
+        expect(response.body.speakerId).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
+
+        const createdSpeaker = await Database.SPEAKERS.findOne({
+                    speakerId: response.body.speakerId,
+                });
+        expect(createdSpeaker?.toObject()).toMatchObject({...NEW_SPEAKER_PAYLOAD_NO_ID, speakerId: response.body.speakerId});
+    });
+
+    it("should create and return a new speaker with provided speakerId when valid speakerId is in payload", async () => {
+        const response = await postAsAdmin("/speakers/").send(NEW_SPEAKER_PAYLOAD_WITH_ID).expect(StatusCodes.CREATED);
+
+        expect(response.body).toMatchObject(NEW_SPEAKER_PAYLOAD_WITH_ID);
+
+        const createdSpeaker = await Database.SPEAKERS.findOne({
+                    speakerId: NEW_SPEAKER_PAYLOAD_WITH_ID.speakerId,
+                });
+        expect(createdSpeaker?.toObject()).toMatchObject(NEW_SPEAKER_PAYLOAD_WITH_ID);
+    });
+
+    it("should return BAD_REQUEST if trying to create a speaker with an already existing speakerId", async () => {
+        const payloadWithExistingId = {
+            ...NEW_SPEAKER_PAYLOAD_NO_ID,
+            speakerId: SPEAKER_1_ID,
+        }
+
+        const response = await postAsStaff("/speakers/").send(payloadWithExistingId).expect(StatusCodes.BAD_REQUEST);
+        expect(response.body).toEqual({ error: "UserAlreadyExists" });
+    })
+
+    const invalidPayloads = [
+        { description: "missing 'name' field", payload: { ...NEW_SPEAKER_PAYLOAD_NO_ID, name: undefined } },
+        { description: "'name' field is not a string", payload: { ...NEW_SPEAKER_PAYLOAD_NO_ID, name: 12345 } },
+        { description: "payload is an empty object", payload: {} },
+    ];
+
+    it.each(invalidPayloads)(
+        "should return BAD_REQUEST when $description in an invalid payload",
+        async ({ payload: invalidData }) => {
+            await postAsStaff("/speakers/")
+                .send(invalidData)
+                .expect(StatusCodes.BAD_REQUEST);
+        }
+    );
+});
+
+describe("PUT /speakers/:SPEAKERID", () => {
+    it("should return UNAUTHORIZED for an unauthenticated user", async () => {
+        await put(`/speakers/${SPEAKER_1.speakerId}`).expect(
+                    StatusCodes.UNAUTHORIZED
+                );
+    });
+
+    it("should update speaker and return 200 OK with updated speaker", async () => {
+        const response = await putAsAdmin(`/speakers/${SPEAKER_1.speakerId}`)
+            .send(UPDATE_SPEAKER_PAYLOAD)
+            .expect(StatusCodes.OK);
+
+        expect(response.body).toMatchObject( {...UPDATE_SPEAKER_PAYLOAD, speakerId: SPEAKER_1_ID} );
+
+        // ensure speakerId was not overwritten
+        expect(response.body.speakerId).toBe(SPEAKER_1_ID);
+
+        const speakerAfterUpdate = await Database.SPEAKERS.findOne({ speakerId: response.body.speakerId });
+        expect(speakerAfterUpdate).toMatchObject( {...UPDATE_SPEAKER_PAYLOAD, speakerId: SPEAKER_1.speakerId} );
+    });
+
+    it("should return 404 NOT_FOUND when trying to update a speaker that does not exist", async()=> {
+        const response = await putAsStaff(`/speakers/${NON_EXISTENT_SPEAKER_ID}`).send(UPDATE_SPEAKER_PAYLOAD).expect(StatusCodes.NOT_FOUND);
+        expect(response.body).toEqual({ error: "DoesNotExist" });
+    })
+
+    const invalidUpdatePayloads = [
+        { description: "missing 'name' field", payload: { ...UPDATE_SPEAKER_PAYLOAD, name: undefined } },
+        { description: "'title' field is not a string", payload: { ...UPDATE_SPEAKER_PAYLOAD, title: 12345 } },
+        { description: "payload is an empty object", payload: {} },
+    ];
+
+    it.each(invalidUpdatePayloads)(
+        "should return BAD_REQUEST when $description when trying to update an existing speaker",
+        async ({ payload: invalidData }) => {
+            await putAsAdmin(`/speakers/${SPEAKER_1_ID}`)
+                .send(invalidData)
+                .expect(StatusCodes.BAD_REQUEST);
+        }
+    );
+    
+});
+
+describe("DELETE /speakers/:SPEAKERID", () => {
+    it("should return UNAUTHORIZED for an unauthenticated user", async () => {
+        await del(`/speakers/${SPEAKER_1.speakerId}`).expect(
+            StatusCodes.UNAUTHORIZED
+        );
+    });
+
+    it("should delete an existing speaker and return 204 NO_CONTENT", async () => {
+        await delAsAdmin(`/speakers/${SPEAKER_1.speakerId}`).expect(StatusCodes.NO_CONTENT);
+        
+        const deletedSpeaker = await Database.SPEAKERS.findOne({ speakerId: SPEAKER_1.speakerId });
+        expect(deletedSpeaker).toBeNull();
+    });
+
+    it("should return NOT_FOUND when trying to delete a speaker that doesn't exist", async () => {
+        const response = await delAsStaff(
+                    `/speakers/${NON_EXISTENT_SPEAKER_ID}`
+                ).expect(StatusCodes.NOT_FOUND);
+                expect(response.body).toEqual({ error: "DoesNotExist" });
+    });
+});

--- a/src/services/speakers/speakers-router.ts
+++ b/src/services/speakers/speakers-router.ts
@@ -59,8 +59,9 @@ speakersRouter.put(
         const speakerId = req.params.SPEAKERID;
 
         const validatedData = SpeakerValidator.parse(req.body);
-        // omit speakerId from validatedData to prevent it from overwritting
-        const { speakerId: _, ...updateData } = validatedData;
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { speakerId: _, ...updateData } = validatedData; // omit speakerId from validatedData to prevent it from overwritting
 
         const speaker = await Database.SPEAKERS.findOneAndUpdate(
             { speakerId: speakerId },

--- a/src/services/speakers/speakers-router.ts
+++ b/src/services/speakers/speakers-router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { StatusCodes } from "http-status-codes";
-import { SpeakerValidator } from "./speakers-schema";
+import { SpeakerValidator, UpdateSpeakerValidator } from "./speakers-schema";
 import { Database } from "../../database";
 import RoleChecker from "../../middleware/role-checker";
 import { Role } from "../auth/auth-models";
@@ -58,14 +58,11 @@ speakersRouter.put(
     async (req, res) => {
         const speakerId = req.params.SPEAKERID;
 
-        const validatedData = SpeakerValidator.parse(req.body);
-
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { speakerId: _, ...updateData } = validatedData; // omit speakerId from validatedData to prevent it from overwritting
+        const updateData = UpdateSpeakerValidator.parse(req.body);
 
         const speaker = await Database.SPEAKERS.findOneAndUpdate(
             { speakerId: speakerId },
-            { $set: updateData }, // updates all fields besides speakerId
+            { $set: updateData },
             { new: true, runValidators: true }
         );
 

--- a/src/services/speakers/speakers-router.ts
+++ b/src/services/speakers/speakers-router.ts
@@ -29,23 +29,27 @@ speakersRouter.get("/:SPEAKERID", RoleChecker([], true), async (req, res) => {
 });
 
 // Create a new speaker
-speakersRouter.post("/", RoleChecker([Role.Enum.ADMIN, Role.Enum.STAFF]), async (req, res) => {
-    const validatedData = SpeakerValidator.parse(req.body);
+speakersRouter.post(
+    "/",
+    RoleChecker([Role.Enum.ADMIN, Role.Enum.STAFF]),
+    async (req, res) => {
+        const validatedData = SpeakerValidator.parse(req.body);
 
-    const existingSpeaker = await Database.SPEAKERS.findOne({
+        const existingSpeaker = await Database.SPEAKERS.findOne({
             speakerId: validatedData.speakerId,
         });
 
-    if (existingSpeaker) {
-        return res
-            .status(StatusCodes.BAD_REQUEST)
-            .json({ error: "UserAlreadyExists" });
-    }
+        if (existingSpeaker) {
+            return res
+                .status(StatusCodes.BAD_REQUEST)
+                .json({ error: "UserAlreadyExists" });
+        }
 
-    const speaker = new Database.SPEAKERS(validatedData);
-    await speaker.save();
-    return res.status(StatusCodes.CREATED).json(speaker);
-});
+        const speaker = new Database.SPEAKERS(validatedData);
+        await speaker.save();
+        return res.status(StatusCodes.CREATED).json(speaker);
+    }
+);
 
 // Update a speaker
 speakersRouter.put(
@@ -56,7 +60,7 @@ speakersRouter.put(
 
         const validatedData = SpeakerValidator.parse(req.body);
         // omit speakerId from validatedData to prevent it from overwritting
-        const { speakerId: _, ...updateData } = validatedData; 
+        const { speakerId: _, ...updateData } = validatedData;
 
         const speaker = await Database.SPEAKERS.findOneAndUpdate(
             { speakerId: speakerId },
@@ -81,12 +85,14 @@ speakersRouter.delete(
     async (req, res) => {
         const speakerId = req.params.SPEAKERID;
 
-        const deletedSpeaker = await Database.SPEAKERS.findOneAndDelete({ speakerId });
-                if (!deletedSpeaker) {
-                    return res
-                        .status(StatusCodes.NOT_FOUND)
-                        .json({ error: "DoesNotExist" });
-                }
+        const deletedSpeaker = await Database.SPEAKERS.findOneAndDelete({
+            speakerId,
+        });
+        if (!deletedSpeaker) {
+            return res
+                .status(StatusCodes.NOT_FOUND)
+                .json({ error: "DoesNotExist" });
+        }
 
         return res.sendStatus(StatusCodes.NO_CONTENT);
     }

--- a/src/services/speakers/speakers-schema.ts
+++ b/src/services/speakers/speakers-schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { v4 as uuidv4 } from "uuid";
 
 export type SpeakerType = z.infer<typeof SpeakerValidator>;
+export type UpdateSpeakerType = z.infer<typeof UpdateSpeakerValidator>;
 
 // Zod schema for speaker
 export const SpeakerValidator = z.object({
@@ -14,6 +15,11 @@ export const SpeakerValidator = z.object({
     eventDescription: z.string(),
     imgUrl: z.string(),
 });
+
+// Zod schema for updating speaker (omits speakerId)
+export const UpdateSpeakerValidator = SpeakerValidator.omit({
+    speakerId: true,
+}).strict();
 
 // Mongoose schema for speaker
 export const SpeakerSchema = new Schema({

--- a/src/services/speakers/speakers-schema.ts
+++ b/src/services/speakers/speakers-schema.ts
@@ -2,6 +2,8 @@ import { Schema } from "mongoose";
 import { z } from "zod";
 import { v4 as uuidv4 } from "uuid";
 
+export type SpeakerType = z.infer<typeof SpeakerValidator>;
+
 // Zod schema for speaker
 export const SpeakerValidator = z.object({
     speakerId: z.coerce.string().default(() => uuidv4()),


### PR DESCRIPTION
- Refactored POST route to return BAD_REQUEST and json with UserAlreadyExists when trying to create a new speaker with the same ID. 
- Fixed bug in PUT route where speakerId was being overwritten. 
- Refactored DELETE route to return NOT_FOUND and json with DoesNotExist when trying to delete a non-existent speaker. - Added ADMIN to roles in each route.
- Added speaker type to speakers schema.
- Added testing for speakers router.