### PR TITLE
Add multi-device endpoints & actual testing

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -43,7 +43,7 @@ export const Config = {
 
     CLIENT_ID: getEnv("OAUTH_GOOGLE_CLIENT_ID"),
     CLIENT_SECRET: getEnv("OAUTH_GOOGLE_CLIENT_SECRET"),
-
+    IOS_CLIENT_ID: getEnv("IOS_OAUTH_GOOGLE_CLIENT_ID"),
     AUTH_CALLBACK_URI_BASE: `${API_BASE}/auth/callback/`,
 
     // prettier-ignore

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,7 @@ export const Config = {
     CLIENT_ID: getEnv("OAUTH_GOOGLE_CLIENT_ID"),
     CLIENT_SECRET: getEnv("OAUTH_GOOGLE_CLIENT_SECRET"),
     IOS_CLIENT_ID: getEnv("IOS_OAUTH_GOOGLE_CLIENT_ID"),
+    ANDROID_CLIENT_ID: getEnv("ANDROID_OAUTH_GOOGLE_CLIENT_ID"),
     AUTH_CALLBACK_URI_BASE: `${API_BASE}/auth/callback/`,
 
     // prettier-ignore

--- a/src/services/auth/auth-models.ts
+++ b/src/services/auth/auth-models.ts
@@ -9,8 +9,13 @@ export const Role = z.enum([
 ]);
 export type Role = z.infer<typeof Role>;
 
-export const Platform = z.enum(["WEB", "IOS"]); // TODO: add ANDROID
-export type Platform = z.infer<typeof Platform>;
+export enum Platform {
+    WEB = "WEB",
+    IOS = "IOS",
+    ANDROID = "ANDROID",
+}
+
+export const PlatformValidator = z.nativeEnum(Platform);
 
 export const JwtPayloadValidator = z.object({
     userId: z.string(),

--- a/src/services/auth/auth-models.ts
+++ b/src/services/auth/auth-models.ts
@@ -10,9 +10,9 @@ export const Role = z.enum([
 export type Role = z.infer<typeof Role>;
 
 export enum Platform {
-    WEB = "WEB",
-    IOS = "IOS",
-    ANDROID = "ANDROID",
+    WEB = "web",
+    IOS = "ios",
+    ANDROID = "android",
 }
 
 export const PlatformValidator = z.nativeEnum(Platform);

--- a/src/services/auth/auth-models.ts
+++ b/src/services/auth/auth-models.ts
@@ -9,6 +9,9 @@ export const Role = z.enum([
 ]);
 export type Role = z.infer<typeof Role>;
 
+export const Platform = z.enum(["WEB", "IOS"]); // TODO: add ANDROID
+export type Platform = z.infer<typeof Platform>;
+
 export const JwtPayloadValidator = z.object({
     userId: z.string(),
     displayName: z.string(),

--- a/src/services/auth/auth-router.test.ts
+++ b/src/services/auth/auth-router.test.ts
@@ -216,7 +216,7 @@ describe("POST /auth/login/:PLATFORM", () => {
                 redirectUri: "http://localhost/redirect",
             })
             .expect(StatusCodes.NOT_FOUND);
-        expect(res.body).toHaveProperty("error", "NotFound");
+        expect(res.body).toHaveProperty("error", "EndpointNotFound");
     });
 
     // Web platform tests

--- a/src/services/auth/auth-router.ts
+++ b/src/services/auth/auth-router.ts
@@ -4,18 +4,38 @@ import { StatusCodes } from "http-status-codes";
 import { Database } from "../../database";
 import RoleChecker from "../../middleware/role-checker";
 import { Role } from "../auth/auth-models";
-import { AuthLoginValidator, AuthRoleChangeRequest } from "./auth-schema";
+import { AuthLoginValidator, AuthRoleChangeRequest, PlatformValidator } from "./auth-schema";
 import authSponsorRouter from "./sponsor/sponsor-router";
 import { CorporateDeleteRequest, CorporateValidator } from "./corporate-schema";
 import { OAuth2Client } from "google-auth-library";
 import { generateJWT, updateDatabaseWithAuthPayload } from "./auth-utils";
 
-const googleOAuthClient = new OAuth2Client({
-    clientId: Config.CLIENT_ID,
-    clientSecret: Config.CLIENT_SECRET,
-});
+const createOAuthClient = (clientId: string, clientSecret?: string) => {
+    return new OAuth2Client({
+        clientId,
+        clientSecret,
+    });
+};
+
+const oauthClients = {
+    web: createOAuthClient(Config.CLIENT_ID, Config.CLIENT_SECRET),
+    ios: createOAuthClient(Config.IOS_CLIENT_ID),
+    // android: createOAuthClient(Config.ANDROID_CLIENT_ID),
+};
+
+
+const getOAuthClient = (platform: string) => {
+    const client = oauthClients[platform as keyof typeof oauthClients];
+    if (!client) {
+        console.warn(`Unknown platform: ${platform}, falling back to web client`);
+        return oauthClients.web;
+    }
+
+    return client;
+};
 
 const authRouter = Router();
+
 
 authRouter.use("/sponsor", authSponsorRouter);
 
@@ -53,16 +73,23 @@ authRouter.put("/", RoleChecker([Role.Enum.ADMIN]), async (req, res) => {
     return res.status(StatusCodes.OK).json(user);
 });
 
-const getAuthPayloadFromCode = async (code: string, redirect_uri: string) => {
+const getAuthPayloadFromCode = async (
+    code: string, 
+    redirect_uri: string, 
+    platform: string = 'web',
+    code_verifier?: string
+) => {
     try {
-        const { tokens } = await googleOAuthClient.getToken({
+        const oauthClient = getOAuthClient(platform);
+        const { tokens } = await oauthClient.getToken({
             code,
             redirect_uri,
+            codeVerifier: code_verifier, // only for mobile apps
         });
         if (!tokens.id_token) {
             throw new Error("Invalid token");
         }
-        const ticket = await googleOAuthClient.verifyIdToken({
+        const ticket = await oauthClient.verifyIdToken({
             idToken: tokens.id_token,
         });
         const payload = ticket.getPayload();
@@ -77,10 +104,12 @@ const getAuthPayloadFromCode = async (code: string, redirect_uri: string) => {
     }
 };
 
-authRouter.post("/login/", async (req, res) => {
-    // Convert id to token
-    const { code, redirectUri } = AuthLoginValidator.parse(req.body);
-    const authPayload = await getAuthPayloadFromCode(code, redirectUri);
+authRouter.post("/login/:platform", async (req, res) => {
+    try {
+        const { code, redirectUri, codeVerifier } = AuthLoginValidator.parse(req.body);
+        const platform = PlatformValidator.parse(req.params.platform);
+        
+        const authPayload = await getAuthPayloadFromCode(code, redirectUri, platform, codeVerifier);
 
     if (!authPayload) {
         return res
@@ -103,23 +132,32 @@ authRouter.post("/login/", async (req, res) => {
     const jwtToken = await generateJWT(`user${authPayload.sub}`);
 
     return res.status(StatusCodes.OK).send({ token: jwtToken });
+    } catch (error) {
+        console.error("Error in platform login:", error);
+        return res.status(StatusCodes.BAD_REQUEST).send({ 
+            error: "InvalidRequest",
+            details: error instanceof Error ? error.message : "Unknown error"
+        });
+    }
 });
 
-authRouter.post("/login/mobile", async (req, res) => {
-    const { idToken } = req.body;
-    let authPayload;
-    const ticket = await googleOAuthClient.verifyIdToken({
-        idToken,
-        audience: Config.IOS_CLIENT_ID,
-    });
-    authPayload = ticket.getPayload();
+
+authRouter.post("/login/", async (req, res) => {
+    const { code, redirectUri } = AuthLoginValidator.parse(req.body);
+    const authPayload = await getAuthPayloadFromCode(code, redirectUri, 'web');
+
     if (!authPayload) {
-        return res.status(StatusCodes.BAD_REQUEST).send({ error: "InvalidToken" });
+        return res
+            .status(StatusCodes.BAD_REQUEST)
+            .send({ error: "InvalidToken" });
     }
+
     const properScopes =
         "email" in authPayload && "sub" in authPayload && "name" in authPayload;
     if (!properScopes) {
-        return res.status(StatusCodes.BAD_REQUEST).send({ error: "InvalidScopes" });
+        return res
+            .status(StatusCodes.BAD_REQUEST)
+            .send({ error: "InvalidScopes" });
     }
 
     // Update database by payload

--- a/src/services/auth/auth-router.ts
+++ b/src/services/auth/auth-router.ts
@@ -95,57 +95,6 @@ const getAuthPayloadFromCode = async (
 authRouter.post("/login/:PLATFORM", async (req, res) => {
     try {
         const platform = Platform.parse(req.params.PLATFORM);
-        const requestBody = { ...req.body, platform };
-        const validatedData = AuthLoginValidator.parse(requestBody);
-
-        const { code, redirectUri } = validatedData;
-        const codeVerifier =
-            "codeVerifier" in validatedData
-                ? validatedData.codeVerifier
-                : undefined;
-
-        const authPayload = await getAuthPayloadFromCode(
-            code,
-            redirectUri,
-            platform,
-            codeVerifier
-        );
-
-        if (!authPayload) {
-            return res
-                .status(StatusCodes.BAD_REQUEST)
-                .send({ error: "InvalidToken" });
-        }
-
-        const properScopes =
-            "email" in authPayload &&
-            "sub" in authPayload &&
-            "name" in authPayload;
-        if (!properScopes) {
-            return res
-                .status(StatusCodes.BAD_REQUEST)
-                .send({ error: "InvalidScopes" });
-        }
-
-        // Update database by payload
-        await updateDatabaseWithAuthPayload(authPayload);
-
-        // Generate the JWT
-        const jwtToken = await generateJWT(`user${authPayload.sub}`);
-
-        return res.status(StatusCodes.OK).send({ token: jwtToken });
-    } catch (error) {
-        console.error("Error in platform login:", error);
-        return res.status(StatusCodes.BAD_REQUEST).send({
-            error: "InvalidRequest",
-            details: error instanceof Error ? error.message : "Unknown error",
-        });
-    }
-});
-
-authRouter.post("/login/:PLATFORM", async (req, res) => {
-    try {
-        const platform = Platform.parse(req.params.PLATFORM);
 
         const requestBody = { ...req.body, platform };
         const validatedData = AuthLoginValidator.parse(requestBody);

--- a/src/services/auth/auth-schema.ts
+++ b/src/services/auth/auth-schema.ts
@@ -1,6 +1,6 @@
 import { InferSchemaType, Schema } from "mongoose";
 import { z } from "zod";
-import { Role, Platform } from "./auth-models";
+import { Platform, Role } from "./auth-models";
 
 export const RoleValidator = z.object({
     userId: z.coerce.string(),
@@ -14,14 +14,17 @@ export const AuthLoginValidator = z.union([
     z.object({
         code: z.string(),
         redirectUri: z.string(),
-        platform: z.literal(Platform.Enum.WEB),
+        platform: z.literal(Platform.WEB),
     }),
     // iOS/Android - codeVerifier is required
     z.object({
         code: z.string(),
         redirectUri: z.string(),
         codeVerifier: z.string(),
-        platform: z.literal(Platform.Enum.IOS), // TODO: add ANDROID
+        platform: z.union([
+            z.literal(Platform.IOS),
+            z.literal(Platform.ANDROID),
+        ]),
     }),
 ]);
 

--- a/src/services/auth/auth-schema.ts
+++ b/src/services/auth/auth-schema.ts
@@ -12,12 +12,16 @@ export const RoleValidator = z.object({
 export const AuthLoginValidator = z.object({
     code: z.string(),
     redirectUri: z.string(),
+    codeVerifier: z.string().optional(),
 });
 
 export const AuthRoleChangeRequest = z.object({
     email: z.string().email(),
     role: z.string(),
 });
+
+// Platform validator for OAuth clients
+export const PlatformValidator = z.enum(["web", "ios", "android"]);
 
 export const RoleSchema = new Schema(
     {

--- a/src/services/auth/auth-schema.ts
+++ b/src/services/auth/auth-schema.ts
@@ -1,6 +1,6 @@
 import { InferSchemaType, Schema } from "mongoose";
 import { z } from "zod";
-import { Role } from "./auth-models";
+import { Role, Platform } from "./auth-models";
 
 export const RoleValidator = z.object({
     userId: z.coerce.string(),
@@ -9,19 +9,26 @@ export const RoleValidator = z.object({
     roles: z.array(Role).default([]),
 });
 
-export const AuthLoginValidator = z.object({
-    code: z.string(),
-    redirectUri: z.string(),
-    codeVerifier: z.string().optional(),
-});
+export const AuthLoginValidator = z.union([
+    // Web platform - no codeVerifier needed
+    z.object({
+        code: z.string(),
+        redirectUri: z.string(),
+        platform: z.literal(Platform.Enum.WEB),
+    }),
+    // iOS/Android - codeVerifier is required
+    z.object({
+        code: z.string(),
+        redirectUri: z.string(),
+        codeVerifier: z.string(),
+        platform: z.literal(Platform.Enum.IOS), // TODO: add ANDROID
+    }),
+]);
 
 export const AuthRoleChangeRequest = z.object({
     email: z.string().email(),
     role: z.string(),
 });
-
-// Platform validator for OAuth clients
-export const PlatformValidator = z.enum(["web", "ios", "android"]);
 
 export const RoleSchema = new Schema(
     {

--- a/src/services/auth/auth-utils.ts
+++ b/src/services/auth/auth-utils.ts
@@ -1,9 +1,33 @@
 // Create a function to generate GoogleStrategy instances
-import { TokenPayload } from "google-auth-library";
+import { OAuth2Client, TokenPayload } from "google-auth-library";
 import { Config } from "../../config";
 import { Database } from "../../database";
 import { JwtPayloadType, Role } from "./auth-models";
 import jsonwebtoken from "jsonwebtoken";
+
+const createOAuthClient = (clientId: string, clientSecret?: string) => {
+    return new OAuth2Client({
+        clientId,
+        clientSecret,
+    });
+};
+
+const oauthClients = {
+    web: createOAuthClient(Config.CLIENT_ID, Config.CLIENT_SECRET),
+    ios: createOAuthClient(Config.IOS_CLIENT_ID),
+};
+
+export const getOAuthClient = (platform: string) => {
+    const client = oauthClients[platform as keyof typeof oauthClients];
+    if (!client) {
+        console.warn(
+            `Unknown platform: ${platform}, falling back to web client`
+        );
+        return oauthClients.web;
+    }
+
+    return client;
+};
 
 export async function updateDatabaseWithAuthPayload(payload: TokenPayload) {
     const userId = `user${payload.sub}`;

--- a/src/services/auth/auth-utils.ts
+++ b/src/services/auth/auth-utils.ts
@@ -5,28 +5,11 @@ import { Database } from "../../database";
 import { JwtPayloadType, Role } from "./auth-models";
 import jsonwebtoken from "jsonwebtoken";
 
-const createOAuthClient = (clientId: string, clientSecret?: string) => {
+export const createOAuthClient = (clientId: string, clientSecret?: string) => {
     return new OAuth2Client({
         clientId,
         clientSecret,
     });
-};
-
-const oauthClients = {
-    web: createOAuthClient(Config.CLIENT_ID, Config.CLIENT_SECRET),
-    ios: createOAuthClient(Config.IOS_CLIENT_ID),
-};
-
-export const getOAuthClient = (platform: string) => {
-    const client = oauthClients[platform as keyof typeof oauthClients];
-    if (!client) {
-        console.warn(
-            `Unknown platform: ${platform}, falling back to web client`
-        );
-        return oauthClients.web;
-    }
-
-    return client;
 };
 
 export async function updateDatabaseWithAuthPayload(payload: TokenPayload) {

--- a/src/services/auth/auth-utils.ts
+++ b/src/services/auth/auth-utils.ts
@@ -1,16 +1,9 @@
 // Create a function to generate GoogleStrategy instances
-import { OAuth2Client, TokenPayload } from "google-auth-library";
+import { TokenPayload } from "google-auth-library";
 import { Config } from "../../config";
 import { Database } from "../../database";
 import { JwtPayloadType, Role } from "./auth-models";
 import jsonwebtoken from "jsonwebtoken";
-
-export const createOAuthClient = (clientId: string, clientSecret?: string) => {
-    return new OAuth2Client({
-        clientId,
-        clientSecret,
-    });
-};
 
 export async function updateDatabaseWithAuthPayload(payload: TokenPayload) {
     const userId = `user${payload.sub}`;

--- a/testing/jest.env-setup.ts
+++ b/testing/jest.env-setup.ts
@@ -4,6 +4,7 @@ process.env.DATABASE_USERNAME = "urmom";
 process.env.DATABASE_PASSWORD = "alsourmom";
 process.env.DATABASE_HOST = "urmomisthebomb.com";
 
+process.env.IOS_OAUTH_GOOGLE_CLIENT_ID = "beepbeepimasheep";
 process.env.OAUTH_GOOGLE_CLIENT_ID = "beepbeepimasheep";
 process.env.OAUTH_GOOGLE_CLIENT_SECRET = "isaidbeepbeepimasheep";
 

--- a/testing/jest.env-setup.ts
+++ b/testing/jest.env-setup.ts
@@ -4,7 +4,8 @@ process.env.DATABASE_USERNAME = "urmom";
 process.env.DATABASE_PASSWORD = "alsourmom";
 process.env.DATABASE_HOST = "urmomisthebomb.com";
 
-process.env.IOS_OAUTH_GOOGLE_CLIENT_ID = "beepbeepimasheep";
+process.env.IOS_OAUTH_GOOGLE_CLIENT_ID = "beepbeepimasheepforapple";
+process.env.ANDROID_OAUTH_GOOGLE_CLIENT_ID = "beepbeepimasheepforandroid";
 process.env.OAUTH_GOOGLE_CLIENT_ID = "beepbeepimasheep";
 process.env.OAUTH_GOOGLE_CLIENT_SECRET = "isaidbeepbeepimasheep";
 

--- a/testing/jest.env-setup.ts
+++ b/testing/jest.env-setup.ts
@@ -4,8 +4,10 @@ process.env.DATABASE_USERNAME = "urmom";
 process.env.DATABASE_PASSWORD = "alsourmom";
 process.env.DATABASE_HOST = "urmomisthebomb.com";
 
-process.env.IOS_OAUTH_GOOGLE_CLIENT_ID = "beepbeepimasheepforapple";
-process.env.ANDROID_OAUTH_GOOGLE_CLIENT_ID = "beepbeepimasheepforandroid";
+process.env.IOS_OAUTH_GOOGLE_CLIENT_ID =
+    "himynameistimothygonzalezandiliketoeatcoldtoastforbreakfastbecauseblahblahblahyouhavetoreadthiswholethingbecauseimyourbosshahahahahah";
+process.env.ANDROID_OAUTH_GOOGLE_CLIENT_ID =
+    "ronitanandanisittinginatreeC-O-D-I-N-Gllamallamallamafurryfurrryfurryryfyryy";
 process.env.OAUTH_GOOGLE_CLIENT_ID = "beepbeepimasheep";
 process.env.OAUTH_GOOGLE_CLIENT_SECRET = "isaidbeepbeepimasheep";
 


### PR DESCRIPTION
**Auth Router**
1. Deprecated /auth/login endpoint in favor of /auth/login/:PLATFORM
  - made PLATFORM into an enum 
  - removed getOAuthClient function in favor of a simple dict
  - used zod.union in AuthLoginValidator for the optional codeVerifier

2. Updated testing for new endpoint
  - Added generic test cases
  - Added iOS test cases

TODO: add functionality for android (part of me wants this to be something for someone on mobile team to get hands on experience with API)
