### PR TITLE
Add staff role adding & cleanup auth to solely use authId

### DIFF
--- a/docker/init-scripts/01-schema.sql
+++ b/docker/init-scripts/01-schema.sql
@@ -136,10 +136,11 @@ CREATE TABLE public."registrations" (
 
 CREATE TABLE public."authInfo" (
     "userId" character varying NOT NULL,
-    "authId" text,
+    "authId" text NOT NULL,
     "email" text NOT NULL,
     "displayName" text NOT NULL,
-    CONSTRAINT "authInfo_pkey" PRIMARY KEY ("userId")
+    CONSTRAINT "authInfo_pkey" PRIMARY KEY ("userId"),
+    CONSTRAINT "authInfo_authId_key" UNIQUE ("authId")
 );
 
 CREATE TABLE public."authRoles" (

--- a/src/services/auth/auth-router.test.ts
+++ b/src/services/auth/auth-router.test.ts
@@ -77,49 +77,6 @@ beforeEach(async () => {
     await SupabaseDB.CORPORATE.insert([CORPORATE_USER, CORPORATE_OTHER_USER]);
 });
 
-describe("POST /auth/", () => {
-    it("should create the user", async () => {
-        const res = await postAsAdmin("/auth/")
-            .send({
-                email: "new@example.com",
-            })
-            .expect(StatusCodes.OK);
-
-        const expected = {
-            userId: RANDOM_UUID,
-            displayName: "",
-            email: "new@example.com",
-        };
-        expect(res.body).toMatchObject(expected);
-
-        const { data } = await SupabaseDB.AUTH_INFO.select()
-            .eq("userId", RANDOM_UUID)
-            .single()
-            .throwOnError();
-        expect(data).toMatchObject({ ...expected, authId: null });
-    });
-
-    it("should fail to create if the user already exists", async () => {
-        const res = await postAsAdmin("/auth/")
-            .send({
-                email: OTHER_USER.email,
-            })
-            .expect(StatusCodes.BAD_REQUEST);
-
-        expect(res.body).toHaveProperty("error", "AlreadyExists");
-    });
-
-    it("should require admin permissions", async () => {
-        const res = await postAsStaff("/auth/")
-            .send({
-                email: "new@example.com",
-            })
-            .expect(StatusCodes.FORBIDDEN);
-
-        expect(res.body).toHaveProperty("error", "Forbidden");
-    });
-});
-
 describe("DELETE /auth/", () => {
     it("should remove the requested role", async () => {
         const res = await delAsAdmin("/auth/")

--- a/src/services/auth/auth-router.ts
+++ b/src/services/auth/auth-router.ts
@@ -4,14 +4,12 @@ import Config from "../../config";
 import RoleChecker from "../../middleware/role-checker";
 import { Platform, Role } from "../auth/auth-models";
 import {
-    AuthCreateUserRequest,
     AuthLoginValidator,
     AuthRoleChangeRequest,
 } from "./auth-schema";
 import authSponsorRouter from "./sponsor/sponsor-router";
 import { CorporateDeleteRequest, CorporateValidator } from "./corporate-schema";
 import {
-    createUserByEmail,
     generateJWT,
     payloadHasProperScopes,
     updateDatabaseWithAuthPayload,
@@ -35,24 +33,6 @@ const oauthClients = {
 };
 
 authRouter.use("/sponsor", authSponsorRouter);
-
-// Create a new user for a specific email
-authRouter.post("/", RoleChecker([Role.Enum.ADMIN]), async (req, res) => {
-    const { email } = AuthCreateUserRequest.parse(req.body);
-
-    const { data: existing } = await SupabaseDB.AUTH_INFO.select()
-        .eq("email", email)
-        .maybeSingle()
-        .throwOnError();
-    if (existing) {
-        return res.status(StatusCodes.BAD_REQUEST).json({
-            error: "AlreadyExists",
-        });
-    }
-
-    const newUser = await createUserByEmail(email);
-    return res.status(StatusCodes.OK).send(newUser);
-});
 
 // Remove role from userId (admin only endpoint)
 authRouter.delete("/", RoleChecker([Role.Enum.ADMIN]), async (req, res) => {

--- a/src/services/auth/auth-schema.ts
+++ b/src/services/auth/auth-schema.ts
@@ -10,10 +10,6 @@ export const RoleValidator = z.object({
     roles: z.array(Role).default([]),
 });
 
-export const AuthCreateUserRequest = z.object({
-    email: z.string().email(),
-});
-
 export const AuthLoginValidator = z.union([
     // Web platform - no codeVerifier needed
     z.object({

--- a/src/services/auth/auth-utils.test.ts
+++ b/src/services/auth/auth-utils.test.ts
@@ -9,6 +9,7 @@ import { Role } from "./auth-models";
 import jsonwebtoken, { JwtPayload } from "jsonwebtoken";
 import Config from "../../config";
 import { SupabaseDB } from "../../supabase";
+import { Staff } from "../staff/staff-schema";
 
 const AUTH_USER = {
     displayName: "The Tester",
@@ -27,6 +28,31 @@ const AUTH_PAYLOAD = {
     email: AUTH_USER.email,
     name: AUTH_USER.displayName,
     sub: AUTH_USER.authId,
+} satisfies Partial<TokenPayloadWithProperScopes> as TokenPayloadWithProperScopes;
+
+const STAFF = {
+    attendances: {},
+    email: "staff@illinois.edu",
+    name: "Staffer",
+    team: "DEV",
+} satisfies Staff;
+
+const AUTH_STAFF_USER = {
+    email: STAFF.email,
+    displayName: "The staff",
+    userId: "4242-4242",
+    authId: "42421123",
+} satisfies AuthInfo;
+const AUTH_STAFF_USER_ROLES = [
+    {
+        userId: AUTH_STAFF_USER.userId,
+        role: Role.Enum.USER,
+    },
+] satisfies AuthRole[];
+const AUTH_STAFF_PAYLOAD = {
+    email: AUTH_STAFF_USER.email,
+    name: AUTH_STAFF_USER.displayName,
+    sub: AUTH_STAFF_USER.authId,
 } satisfies Partial<TokenPayloadWithProperScopes> as TokenPayloadWithProperScopes;
 
 const AUTH_ADMIN_USER = {
@@ -58,11 +84,14 @@ jest.mock("crypto", () => {
 });
 
 beforeEach(async () => {
+    await SupabaseDB.STAFF.insert(STAFF)
     await SupabaseDB.AUTH_INFO.insert([
         AUTH_USER,
+        AUTH_STAFF_USER,
         AUTH_ADMIN_USER,
     ]).throwOnError();
     await SupabaseDB.AUTH_ROLES.insert(AUTH_USER_ROLES);
+    await SupabaseDB.AUTH_ROLES.insert(AUTH_STAFF_USER_ROLES);
     await SupabaseDB.AUTH_ROLES.insert(AUTH_ADMIN_USER_ROLES);
 });
 
@@ -88,13 +117,14 @@ describe("updateDatabaseWithAuthPayload", () => {
         expect(roles?.map((entry) => entry.role)).toEqual([]);
     });
 
-    it("should update a partial user", async () => {
+    it("should update a outdated user", async () => {
         await SupabaseDB.AUTH_INFO.delete().eq("userId", AUTH_USER.userId);
         await SupabaseDB.AUTH_ROLES.delete().eq("userId", AUTH_USER.userId);
         await SupabaseDB.AUTH_INFO.insert({
+            authId: AUTH_USER.authId,
             userId: AUTH_USER.userId,
-            displayName: AUTH_USER.displayName,
-            email: AUTH_USER.email,
+            displayName: "old display name",
+            email: "old@dinosaur.com",
         });
         await SupabaseDB.AUTH_ROLES.insert({
             userId: AUTH_USER.userId,
@@ -128,6 +158,53 @@ describe("updateDatabaseWithAuthPayload", () => {
             AUTH_USER.userId
         );
         expect(roles?.map((entry) => entry.role)).toEqual([Role.Enum.USER]);
+    });
+
+    it("should create a new staff user", async () => {
+        await SupabaseDB.AUTH_INFO.delete().eq(
+            "userId",
+            AUTH_STAFF_USER.userId
+        );
+        await SupabaseDB.AUTH_ROLES.delete().eq(
+            "userId",
+            AUTH_STAFF_USER.userId
+        );
+
+        const updatedUserId =
+            await updateDatabaseWithAuthPayload(AUTH_STAFF_PAYLOAD);
+        expect(updatedUserId).toBe(RANDOM_UUID);
+
+        const { data: info } = await SupabaseDB.AUTH_INFO.select()
+            .eq("userId", updatedUserId)
+            .single();
+        expect(info).toMatchObject({
+            ...AUTH_STAFF_USER,
+            userId: updatedUserId,
+        });
+        const { data: roles } = await SupabaseDB.AUTH_ROLES.select().eq(
+            "userId",
+            updatedUserId
+        );
+        expect(roles?.map((entry) => entry.role)).toEqual([Role.Enum.STAFF]);
+    });
+
+    it("should update a new staff user", async () => {
+        const updatedUserId =
+            await updateDatabaseWithAuthPayload(AUTH_STAFF_PAYLOAD);
+        expect(updatedUserId).toBe(AUTH_STAFF_USER.userId);
+
+        const { data: info } = await SupabaseDB.AUTH_INFO.select()
+            .eq("userId", AUTH_STAFF_USER.userId)
+            .single();
+        expect(info).toMatchObject(AUTH_STAFF_USER);
+        const { data: roles } = await SupabaseDB.AUTH_ROLES.select().eq(
+            "userId",
+            AUTH_STAFF_USER.userId
+        );
+        expect(roles?.map((entry) => entry.role)).toEqual([
+            Role.Enum.USER,
+            Role.Enum.STAFF,
+        ]);
     });
 
     it("should create a new admin user", async () => {

--- a/src/services/auth/auth-utils.ts
+++ b/src/services/auth/auth-utils.ts
@@ -17,18 +17,6 @@ export function payloadHasProperScopes(
     return "email" in payload && "sub" in payload && "name" in payload;
 }
 
-export async function createUserByEmail(email: string) {
-    const { data } = await SupabaseDB.AUTH_INFO.insert({
-        userId: randomUUID(),
-        email,
-        displayName: "",
-    })
-        .select()
-        .single()
-        .throwOnError();
-    return data;
-}
-
 export async function updateDatabaseWithAuthPayload(
     payload: TokenPayloadWithProperScopes
 ): Promise<string> {
@@ -36,9 +24,9 @@ export async function updateDatabaseWithAuthPayload(
     const displayName = payload.name;
     const email = payload.email;
 
-    // Check for an existing user with matching email
+    // Check for an existing user
     const { data } = await SupabaseDB.AUTH_INFO.select("userId")
-        .eq("email", email)
+        .eq("authId", authId)
         .maybeSingle()
         .throwOnError();
 
@@ -52,15 +40,24 @@ export async function updateDatabaseWithAuthPayload(
         displayName,
         userId,
     })
-        .eq("userId", userId)
+        .eq("authId", authId)
         .throwOnError();
+
+    // If the user is STAFF, add the staff role to them
+    const {data: staff} = await SupabaseDB.STAFF.select().eq("email", email).maybeSingle();
+    if (staff) {
+        await SupabaseDB.AUTH_ROLES.upsert({
+            userId,
+            role: Role.Enum.STAFF,
+        }).eq("userId", userId);
+    }
 
     // If the user is ADMIN, add the admin role to them
     if (Config.AUTH_ADMIN_WHITELIST.has(email)) {
         await SupabaseDB.AUTH_ROLES.upsert({
             userId,
             role: Role.Enum.ADMIN,
-        }).eq("email", email);
+        }).eq("userId", userId);
     }
 
     // Return the userId updated

--- a/src/supabase.types.ts
+++ b/src/supabase.types.ts
@@ -156,19 +156,19 @@ export type Database = {
             };
             authInfo: {
                 Row: {
-                    authId: string | null;
+                    authId: string;
                     displayName: string;
                     email: string;
                     userId: string;
                 };
                 Insert: {
-                    authId?: string | null;
+                    authId: string;
                     displayName: string;
                     email: string;
                     userId: string;
                 };
                 Update: {
-                    authId?: string | null;
+                    authId?: string;
                     displayName?: string;
                     email?: string;
                     userId?: string;


### PR DESCRIPTION
- Adds staff check to add staff role automatically to staff users & removed create authInfo endpoint
- Makes `authId` strictly required and unique
- Updates to email/displayName will still pair to the same user
- Race condition based on `authId` partially fixed
  - Will result in second request updating user id again, but will still be the same key user
  - Notably this means the first request's jwt will allow for erronenous actions, but ultimately won't break if second request jwt used. Only true fix is transactions.

This essentially means the proper flow is to create staff users through staff service, and auth will automatically give staff roles to specified emails. This is much cleaner than the previous manual solution.