### PR TITLE
Do proper sourcemap for errors

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
         {
             name: "RP_API",
             script: "build/src/app.js",
+            node_args: "--enable-source-maps",
             wait_ready: true,
             instances: 2,
             listen_timeout: 10 * 1000,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "compilerOptions": {
         "target": "ESNext",
         "useDefineForClassFields": true,
+        "sourceMap": true,
         "module": "CommonJS",
         "lib": ["ESNext", "DOM"],
         "moduleResolution": "node",


### PR DESCRIPTION
Error logs will now have the mapped ts file location instead of the js file location when possible