### PR TITLE
Warn on missing env in prod

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,13 @@ export const MailingListName = z.enum(["rp_interest"]);
 function getEnv(key: string): string {
     const val = process.env[key];
     if (val === undefined) {
+        if (Config.ENV == EnvironmentEnum.PRODUCTION) {
+            console.warn(
+                `env value ${key} not found, defaulting to empty string`
+            );
+            return "";
+        }
+
         throw new Error(`env value ${key} not found, exiting...`);
     }
     return val;


### PR DESCRIPTION
- Currently, we throw an error if ANY env keys are missing
- This is bad for production since a missing env key will result in the API going down
- To resolve this, we should instead issue a warning and default to an empty string