### PR TITLE
Food wave notifications enrollment

### DIFF
--- a/src/services/checkin/checkin-utils.ts
+++ b/src/services/checkin/checkin-utils.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import { Config } from "../../config";
 import { EventType } from "../events/events-schema";
 import { DayKey } from "../attendee/attendee-schema";
+import { getFirebaseAdmin } from "../../firebase";
 
 export function getCurrentDay() {
     const currDate = new Date();
@@ -55,6 +56,20 @@ async function updateAttendeePriority(userId: string) {
     })
         .eq("userId", userId)
         .throwOnError();
+    // subscribe them to the food wave 1 topic for today
+    const { data: userDevice } = await SupabaseDB.NOTIFICATIONS.select(
+        "deviceId"
+    )
+        .eq("userId", userId)
+        .maybeSingle()
+        .throwOnError();
+    if (!userDevice?.deviceId) {
+        return; // we can just be done here if they don't have a deviceId
+    }
+    const topicName = `food-wave-1-${day.toLowerCase()}`;
+    await getFirebaseAdmin()
+        .messaging()
+        .subscribeToTopic(userDevice.deviceId, topicName);
 }
 
 async function updateAttendanceRecords(eventId: string, userId: string) {

--- a/src/services/notifications/notifications-router.test.ts
+++ b/src/services/notifications/notifications-router.test.ts
@@ -4,6 +4,7 @@ import { StatusCodes } from "http-status-codes";
 import { SupabaseDB } from "../../database";
 import { v4 as uuidv4 } from "uuid";
 import { TESTER } from "../../../testing/testingTools";
+import { getCurrentDay } from "../checkin/checkin-utils";
 
 const mockSubscribe = jest.fn();
 const mockUnsubscribe = jest.fn();
@@ -188,6 +189,8 @@ describe("/notifications", () => {
     describe("GET /notifications/topics", () => {
         const TEST_EVENT_ID = uuidv4();
         const TEST_TOPIC_NAME = "food_wave_1";
+        const day = getCurrentDay();
+        const currentDayTopic = `food-wave-1-${day.toLowerCase()}`;
 
         beforeEach(async () => {
             await SupabaseDB.EVENTS.insert({
@@ -216,6 +219,7 @@ describe("/notifications", () => {
             const expectedTopics = [
                 "allUsers",
                 `event_${TEST_EVENT_ID}`,
+                currentDayTopic,
                 "food_wave_1",
             ].sort();
 

--- a/src/services/notifications/notifications-router.ts
+++ b/src/services/notifications/notifications-router.ts
@@ -9,6 +9,7 @@ import {
 } from "./notifications-schema";
 import { SupabaseDB } from "../../database";
 import { getFirebaseAdmin } from "../../firebase";
+import { getCurrentDay } from "../checkin/checkin-utils";
 
 const notificationsRouter = Router();
 
@@ -148,7 +149,9 @@ notificationsRouter.get(
     "/topics",
     RoleChecker([Role.enum.ADMIN]),
     async (req, res) => {
-        const staticTopics = ["allUsers"]; // add any other static topics to this array in future
+        const day = getCurrentDay();
+        const currentDayTopic = `food-wave-1-${day.toLowerCase()}`;
+        const staticTopics = ["allUsers", currentDayTopic]; // add any other static topics to this array in future
 
         const { data: events } =
             await SupabaseDB.EVENTS.select("eventId").throwOnError();


### PR DESCRIPTION
* Updated the updateAttendeePriority function so that when someone's priority updates, it subscribes them to the food wave 1 topic for today
* In our endpoint to get the list of all topics we can send a notification to, I put in the food wave for the current day. Did it this way so that on the admin site, the previous days' wave 1 notification topics don't clog up the list of available topics
* This does imply that we don't have a way to target only food wave 2 users, but we can send a notification to only wave 1 at first and then notify everyone when it's time for wave 2