### PR TITLE
Making notifications topics dropdown more intuitive

### DIFF
--- a/src/services/notifications/notifications-router.test.ts
+++ b/src/services/notifications/notifications-router.test.ts
@@ -218,7 +218,7 @@ describe("/notifications", () => {
 
             const expectedTopics = [
                 "allUsers",
-                `event_${TEST_EVENT_ID}`,
+                `event_Test Event`,
                 currentDayTopic,
                 "food_wave_1",
             ].sort();

--- a/src/services/notifications/notifications-router.ts
+++ b/src/services/notifications/notifications-router.ts
@@ -154,9 +154,8 @@ notificationsRouter.get(
         const staticTopics = ["allUsers", currentDayTopic]; // add any other static topics to this array in future
 
         const { data: events } =
-            await SupabaseDB.EVENTS.select("eventId").throwOnError();
-        const eventTopics =
-            events.map((event) => `event_${event.eventId}`) ?? [];
+            await SupabaseDB.EVENTS.select("name").throwOnError();
+        const eventTopics = events.map((event) => `event_${event.name}`) ?? [];
         const { data: customTopicsData } =
             await SupabaseDB.CUSTOM_TOPICS.select("topicName").throwOnError();
         const customTopics =


### PR DESCRIPTION
* Notifications topics dropdown used to have event IDs, changed this to be event names so it is way more readable and makes more sense
* Tested this on my local using the prod event data, it works
* Updated test to reflect the change