### PR TITLE
Insert a day's promotions into the customTopics table

### DIFF
--- a/src/services/leaderboard/leaderboard-utils.ts
+++ b/src/services/leaderboard/leaderboard-utils.ts
@@ -221,6 +221,12 @@ export async function promoteUsersToNextTier(
         await getFirebaseAdmin()
             .messaging()
             .subscribeToTopic(deviceTokens, topicName);
+        // Add today's tier promotion day
+        await SupabaseDB.CUSTOM_TOPICS.upsert({
+                topicName: topicName,
+            },
+            { onConflict: "topicName", ignoreDuplicates: true }
+        ).throwOnError();
     }
 
     return data || 0;


### PR DESCRIPTION
* When the promote function gets called, it will create a customTopic object with the promotion for that day
* The reason I didn't hardcode the current day into the endpoint (similar to how food wave is done) is in case we want to notify people who got promoted the previous day(s)